### PR TITLE
Make improvement tag exempt from being stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,4 +17,4 @@ jobs:
         stale-issue-label: 'stale'
         days-before-stale: 90
         days-before-close: 15
-        exempt-issue-labels: 'priority, never-stale' 
+        exempt-issue-labels: 'priority, never-stale, improvement' 


### PR DESCRIPTION
probably makes sense, feature requests don't really go stale